### PR TITLE
fix `current-tab-indicator` offset in firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - ✅ Powerful built-in Directives(including ability to create your own)
 - ✅ Client and Server Side Rendering
 - ✅ Works with other library and frameworks
-- 🚫 No Build Required!
+- ✅ No Build Required!
 - 🚫 No JSX!
 - 🚫 No Virtual DOM!
 - 🚫 No Weird HTML or Javascript Syntax!

--- a/docs/index.html
+++ b/docs/index.html
@@ -736,7 +736,7 @@
 	                flex: 1;
 	                width: 100%;
 	                height: 100%;
-
+	                position: relative;
 	            }
 
 	            footer {


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/59403389/147952366-98ae7222-52fe-465a-8cfc-8c1d367f2222.png)

after:
![after](https://user-images.githubusercontent.com/59403389/147952355-dbe4889e-22aa-48ab-bcda-3175b613180b.png)

- [x] chrome works the same, still
